### PR TITLE
Remove Message Group ID processing

### DIFF
--- a/src/test/java/uk/gov/caz/notify/messaging/MessagingClientTest.java
+++ b/src/test/java/uk/gov/caz/notify/messaging/MessagingClientTest.java
@@ -82,7 +82,7 @@ public class MessagingClientTest {
     Mockito.when(govUkNotifyWrapper.sendEmail(templateId, emailAddress, personalisation, reference))
         .thenThrow(err);
 
-    messagingClient.handleMessage(sendEmailRequest, messageGroupId);
+    messagingClient.handleMessage(sendEmailRequest);
 
     Mockito.verify(govUkNotifyWrapper, times(1)).sendEmail(templateId, emailAddress,
         personalisation, reference);
@@ -99,7 +99,7 @@ public class MessagingClientTest {
     Mockito.when(govUkNotifyWrapper.sendEmail(templateId, emailAddress, personalisation, reference))
         .thenThrow(err);
 
-    messagingClient.handleMessage(sendEmailRequest, messageGroupId);
+    messagingClient.handleMessage(sendEmailRequest);
 
     Mockito.verify(govUkNotifyWrapper, times(1)).sendEmail(templateId, emailAddress,
         personalisation, reference);
@@ -116,7 +116,7 @@ public class MessagingClientTest {
     Mockito.when(govUkNotifyWrapper.sendEmail(templateId, emailAddress, personalisation, reference))
         .thenThrow(err);
 
-    messagingClient.handleMessage(sendEmailRequest, messageGroupId);
+    messagingClient.handleMessage(sendEmailRequest);
 
     Mockito.verify(govUkNotifyWrapper, times(4)).sendEmail(templateId, emailAddress,
         personalisation, reference);
@@ -133,7 +133,7 @@ public class MessagingClientTest {
     Mockito.when(govUkNotifyWrapper.sendEmail(templateId, emailAddress, personalisation, reference))
         .thenThrow(err);
 
-    messagingClient.handleMessage(sendEmailRequest, messageGroupId);
+    messagingClient.handleMessage(sendEmailRequest);
 
     Mockito.verify(govUkNotifyWrapper, times(4)).sendEmail(templateId, emailAddress,
         personalisation, reference);
@@ -150,7 +150,7 @@ public class MessagingClientTest {
     Mockito.when(govUkNotifyWrapper.sendEmail(templateId, emailAddress, personalisation, reference))
         .thenThrow(err);
 
-    messagingClient.handleMessage(sendEmailRequest, messageGroupId);
+    messagingClient.handleMessage(sendEmailRequest);
 
     Mockito.verify(govUkNotifyWrapper, times(4)).sendEmail(templateId, emailAddress,
         personalisation, reference);
@@ -167,7 +167,7 @@ public class MessagingClientTest {
         .thenThrow(err);
     Mockito.when(err.getMessage()).thenReturn("Error thrown successfully.");
 
-    messagingClient.handleMessage(sendEmailRequest, messageGroupId);
+    messagingClient.handleMessage(sendEmailRequest);
 
     Mockito.verify(govUkNotifyWrapper, times(4)).sendEmail(templateId, emailAddress,
         personalisation, reference);
@@ -185,7 +185,7 @@ public class MessagingClientTest {
     Mockito.when(govUkNotifyWrapper.sendEmail(templateId, emailAddress, "{", reference))
         .thenThrow(err);
 
-    messagingClient.handleMessage(sendEmailRequest, messageGroupId);
+    messagingClient.handleMessage(sendEmailRequest);
 
     Mockito.verify(govUkNotifyWrapper, times(1)).sendEmail(templateId, emailAddress, "{",
         reference);

--- a/src/test/java/uk/gov/caz/notify/service/MessageHandlingServiceTest.java
+++ b/src/test/java/uk/gov/caz/notify/service/MessageHandlingServiceTest.java
@@ -85,9 +85,8 @@ public class MessageHandlingServiceTest {
     // assertions
     Mockito.verify(amazonSqs, times(1)).receiveMessage(Mockito.any(ReceiveMessageRequest.class));
     Mockito.verify(amazonSqs, times(2)).deleteMessage("testUrl", "testHandle");
-    Mockito.verify(messagingClient, times(1)).publishMessage(null, "", "testId");
-    Mockito.verify(messagingClient, times(1)).handleMessage(Mockito.any(SendEmailRequest.class),
-        Mockito.anyString());
+    Mockito.verify(messagingClient, times(1)).publishMessage(null, "");
+    Mockito.verify(messagingClient, times(1)).handleMessage(Mockito.any(SendEmailRequest.class));
 
   }
 


### PR DESCRIPTION
**Due to the following section of SQS developer guide:**

> To avoid processing duplicate messages in a system with multiple producers and consumers where throughput and latency are more important than ordering, the producer should generate a unique message group ID for each message.

As sending emails is intrinsically an unordered process (Person A doesn't care if Person B gets a payment receipt before or after them, the mailbox doesn't care if it receives feedback forms in a different order than they were submitted), generating unique message group IDs for each message seems a sensible performance optimisation.

**Vehicle Checker & Payments should both be updated in accordance to set the Message Group ID to a random UUID.**