### PR TITLE
[CAZB-4051] Externalise SQS message receive wait time

### DIFF
--- a/src/main/java/uk/gov/caz/notify/service/MessageHandlingService.java
+++ b/src/main/java/uk/gov/caz/notify/service/MessageHandlingService.java
@@ -29,6 +29,9 @@ public class MessageHandlingService {
 
   @Value("${application.message-batch-rate}")
   private int messageBatchRate;
+  
+  @Value("${application.sqs-request-wait-time}")
+  private int sqsRequestWaitTime;
 
   @Value("${job.notify-gateway.dlq-url}")
   private String dlqName;
@@ -84,7 +87,8 @@ public class MessageHandlingService {
     this.queueUrl = getQueueUrlResult.getQueueUrl();
 
     ReceiveMessageRequest messageRequest =
-        new ReceiveMessageRequest(this.queueUrl).withWaitTimeSeconds(5)
+        new ReceiveMessageRequest(this.queueUrl)
+            .withWaitTimeSeconds(sqsRequestWaitTime)
             .withMaxNumberOfMessages(messageBatchRate)
             .withAttributeNames("MessageGroupId");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,7 @@ application:
   message-batch-rate: 10
   message-group-id-payments: PAYMENTS_RECEIPT
   polling-iterations: 1
+  sqs-request-wait-time: 0
 
 job:
   notify-gateway:


### PR DESCRIPTION
Externalise SQS message receive wait time as a variable with a default value of 0 for short polling